### PR TITLE
Use firstOrNull in NameCacheService to not throw for uncached players

### DIFF
--- a/src/main/kotlin/gg/flyte/twilight/data/service/NameCacheService.kt
+++ b/src/main/kotlin/gg/flyte/twilight/data/service/NameCacheService.kt
@@ -38,14 +38,15 @@ object NameCacheService {
 
     private fun queryMongoNameByUUID(uuid: UUID): String? {
         mongoCache.let {
-            mongoCache.find(Filters.eq("_id", uuid.toString())).first()
-                .let {
+            mongoCache.find(Filters.eq("_id", uuid.toString())).firstOrNull()
+                ?.let {
                     val name =
                         it.getString("name") ?: throw MongoException("Document with '_id' '$uuid' has no field 'name'.")
                     cache[uuid] = name
                     return name
                 }
         }
+        return null
     }
 
     private fun queryMojangNameByUUID(uuid: UUID): String {
@@ -78,13 +79,14 @@ object NameCacheService {
                     "name",
                     Pattern.compile("^$name$", Pattern.CASE_INSENSITIVE)
                 )
-            ).first().let {
+            ).firstOrNull()?.let {
                 val uuid = UUID.fromString(it.getString("_id"))
                     ?: throw MongoException("Document with 'name' '$name' has no valid UUID at '_id'.")
                 cache[uuid] = name
                 return uuid
             }
         }
+        return null
     }
 
     private fun queryMojangUUIDByName(name: String): UUID {


### PR DESCRIPTION
I get this when trying to use NameCacheService:
```
com.mongodb.MongoClientException: No results available
	at PunishmentManager-1.0-dev-all.jar/com.mongodb.kotlin.client.MongoIterable.first(MongoIterable.kt:41) ~[PunishmentManager-1.0-dev-all.jar:?]
	at PunishmentManager-1.0-dev-all.jar/gg.flyte.twilight.data.service.NameCacheService.queryMongoNameByUUID(NameCacheService.kt:41) ~[PunishmentManager-1.0-dev-all.jar:?]
	at PunishmentManager-1.0-dev-all.jar/gg.flyte.twilight.data.service.NameCacheService.nameFromUUID(NameCacheService.kt:36) ~[PunishmentManager-1.0-dev-all.jar:?]
	at PunishmentManager-1.0-dev-all.jar/dev.kingrabbit.punishmentManager.listeners.ChatListener.onChat(ChatListener.kt:24) ~[PunishmentManager-1.0-dev-all.jar:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor2.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77) ~[paper-api-1.21.3-R0.1-SNAPSHOT.jar:?]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.21.3-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.21.3-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.21.3.jar:1.21.3-81-da71382]
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[paper-1.21.3.jar:1.21.3-81-da71382]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[paper-api-1.21.3-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.adventure.ChatProcessor.post(ChatProcessor.java:378) ~[paper-1.21.3.jar:1.21.3-81-da71382]
	at io.papermc.paper.adventure.ChatProcessor.process(ChatProcessor.java:85) ~[paper-1.21.3.jar:1.21.3-81-da71382]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.chat(ServerGamePacketListenerImpl.java:2437) ~[paper-1.21.3.jar:1.21.3-81-da71382]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.broadcastChatMessage(ServerGamePacketListenerImpl.java:2553) ~[paper-1.21.3.jar:1.21.3-81-da71382]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$handleChat$9(ServerGamePacketListenerImpl.java:2201) ~[paper-1.21.3.jar:1.21.3-81-da71382]
	at net.minecraft.util.FutureChain.lambda$append$1(FutureChain.java:25) ~[paper-1.21.3.jar:1.21.3-81-da71382]
	at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:718) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```
This PR should hopefully fix that, as fmu the error is caused by the mongo cache lookup using `first()` instead of `firstOrNull`.  By using `firstOrNull`, the lookup util can then move on to checking the mojang api if it's not cached in mongo.