### PR TITLE
Added the option to use a default click event in GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,9 @@ You can, of course, also implement GUIs for other inventory types:
 val dropperGui = gui(Component.text("Title"), 9, InventoryType.DROPPER) {
     // You can also set multiple indexes at once
     set(listOf(1, 3, 4, 5, 7), ItemStack(Material.GRAY_STAINED_GLASS_PANE))
+
+    // You can also cancel all clicks that occur while the GUI is open
+    onClick { isCancelled = true }
 }
 player.openInventory(dropperGui)
 ```

--- a/src/main/kotlin/gg/flyte/twilight/gui/GUI.kt
+++ b/src/main/kotlin/gg/flyte/twilight/gui/GUI.kt
@@ -30,8 +30,8 @@ class GUI(val title: Component, val size: Int, val type: InventoryType, val cont
     lateinit var viewer: Player
 
     private val clickEvent = event<InventoryClickEvent> {
+        if (inventory == this@GUI.inventory) slotAction[-1]?.invoke(this)
         if (clickedInventory != this@GUI.inventory) return@event
-        slotAction[-1]?.invoke(this)
         slotAction[slot]?.invoke(this)
     }
 
@@ -41,6 +41,9 @@ class GUI(val title: Component, val size: Int, val type: InventoryType, val cont
         }
     }
 
+    /**
+     * Set the action to be executed when the player clicks on any slot while the GUI is open.
+     */
     fun onClick(action: InventoryClickEvent.() -> Unit) {
         slotAction[-1] = action
     }

--- a/src/main/kotlin/gg/flyte/twilight/gui/GUI.kt
+++ b/src/main/kotlin/gg/flyte/twilight/gui/GUI.kt
@@ -31,6 +31,7 @@ class GUI(val title: Component, val size: Int, val type: InventoryType, val cont
 
     private val clickEvent = event<InventoryClickEvent> {
         if (clickedInventory != this@GUI.inventory) return@event
+        slotAction[-1]?.invoke(this)
         slotAction[slot]?.invoke(this)
     }
 
@@ -38,6 +39,10 @@ class GUI(val title: Component, val size: Int, val type: InventoryType, val cont
         for ((index, value) in pattern.joinToString("").withIndex()) {
             keySlot.getOrPut(value) { mutableListOf() }.add(index)
         }
+    }
+
+    fun onClick(action: InventoryClickEvent.() -> Unit) {
+        slotAction[-1] = action
     }
 
     @JvmName("setSlot")


### PR DESCRIPTION
A simple change to allow users to specify a default action to occur on click in GUIs.

My specific use case is to cancel all clicks in the inventory, although I'd imagine there are other uses:
```kotlin
onClick {
    isCancelled = true
}
```